### PR TITLE
Fix like counter not appearing

### DIFF
--- a/project2-front/src/component/Post/DisplayPost/InteractionBar.jsx
+++ b/project2-front/src/component/Post/DisplayPost/InteractionBar.jsx
@@ -28,6 +28,15 @@ const InteractionBar = ({ post, setPost }) => {
             setIsLiked(likeStatus);
         };
         checkLikeStatus();
+
+        const setInitialLikes = async () => {
+            const likes = await getLikes(post.id);
+            setPost({
+                ...post,
+                likes: likes,
+            });
+        }
+        setInitialLikes();
     }, [post.likes, post.id, isUserLike]);
 
     const handleComments =  () => {


### PR DESCRIPTION
PR to fix the counter not appearing until a user presses like